### PR TITLE
Handle ctrl + C not working

### DIFF
--- a/client/sources/main.cpp
+++ b/client/sources/main.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 void handleControlC(int signal) {
-    std::cout << "ctrl+C signal(" + std::to_string(signal) + "), disconnecting client...";
+    std::cout << std::endl << "ctrl+C signal(" + std::to_string(signal) + "), disconnecting client..." << std::endl;
     exit(signal);
 }
 


### PR DESCRIPTION
## What
- Assign a custom handler to `SIGINT` using [`signal`](https://man7.org/linux/man-pages/man2/signal.2.html)


## Why
It's on specs ¯\_(ツ)_/¯ 

We want to gracefully disconnect from server if ctrl + C is identified.

**Attention:** I tested in Xcode and CLion, this doesn't work when running directly from the IDE, you have to manually run from the terminal.

```
→ ./client 
 ::::::: Zap ::::::: 
Como quer ser chamado?
^C
ctrl+C signal(2), disconnecting client...
```

### Sample code
```
#include <iostream>

typedef void (*sighandler_t)(int);
bool keepRunning = true;

void mySIGINTHandler(int signal) {
    std::cout << "keepRunning: " << keepRunning << std::endl;
    std::cout << "Saindo com sinal " << signal << std::endl;
    keepRunning = false;
    std::cout << "keepRunning: " << keepRunning << std::endl;
}

int main(int argc, const char * argv[]) {
    
    std::cout << "Signal" << std::endl;
    sighandler_t SIGINTDefaultHandler = signal(SIGINT, mySIGINTHandler);
    
    std::cout << "While" << std::endl;
    while (keepRunning) {
        // yield
    }
    
    signal(SIGINT, SIGINTDefaultHandler);
    
    std::cout << "Terminando";
    
    return 0;
}
```

### Output
```
valcanaia@Henrique-MBP18:~/Google Drive/UFRGS/2020-1/SISOP 2/CtrlC/DerivedData/CtrlC/Build/Products/Debug on master [!?] [11:34:51]
→ ./CtrlC 
Signal
While
^CkeepRunning: 1
Saindo com sinal 2
keepRunning: 0
Terminando
```

## References
https://man7.org/linux/man-pages/man2/signal.2.html
