### PR TITLE
Moving the read file pointer to the correct offset

### DIFF
--- a/server/sources/Persistency/ServerPersistency.cpp
+++ b/server/sources/Persistency/ServerPersistency.cpp
@@ -60,6 +60,12 @@ int ServerPersistency::readMessages(string group, int messageCount, std::list<Me
 
     const auto bytesToRead = std::min(fileSize, messagesSize);
 
+    // Moving file pointer to the offset of the last massages to be read
+    if(bytesToRead < fileSize) {
+        int lastMessagesOffset = fileSize - messagesSize;
+        file.seekg(lastMessagesOffset, std::ios::beg);
+    }
+
     char *buffer = new char[bytesToRead]();
 
     file.read(buffer, bytesToRead);


### PR DESCRIPTION
#What
- Moving file pointer to the correct offset to start reading the last messages

#Why
- When the user is connected to a group we need two send it the last _N_ messages of that group